### PR TITLE
add negative margin to offset padding on nav hover

### DIFF
--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -18,6 +18,7 @@
         @include box-link-styles;
         &:hover {
             padding-top: 20px;
+            margin-bottom: -20px;
         }
 
         // Gaps between nav items, but not on the first one


### PR DESCRIPTION
Cool site! I noticed the extra padding on nav item hover makes the content jump around beneath it and this bothered me, so I added some negative margin to keep the content from moving. If you disagree, by all means ignore this request.